### PR TITLE
对TextUI进行修改，并定义相关API接口

### DIFF
--- a/public/css/content-theme/classic.css
+++ b/public/css/content-theme/classic.css
@@ -1,0 +1,144 @@
+/*!
+ * Classic content theme of ficus-editor
+ *
+ */
+@import url('https://fonts.googleapis.com/css2?family=Noto+Serif+SC:wght@100;300;400;500;700;900&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@100;300;400;500;700;900&display=swap');
+
+:root {
+  --White: #FFFFFF;
+  --TextMedium: #3D3D3D;
+  --TextRegular: #5E5E5E;
+  --TextLight: #D8D8D8;
+  --TextQuote: #AAAAAA;
+  --SwissCoffee-500: #F4F4F3;
+}
+
+.vditor-reset {
+  font-family: "Noto Serif SC";
+  font-weight: 400px;
+}
+
+/* 段落 */
+
+.vditor-reset p {
+  font-weight: 400; /* Regular */
+  font-size: 12px;
+  line-height: 18px;
+  color: var(--TextMedium);
+  text-align: justify;
+  vertical-align: center;
+  margin-bottom: 12px;
+}
+
+.vditor-reset p b, 
+.vditor-reset p strong {
+  font-weight: 900;
+} 
+
+/* 标题 */
+
+.vditor-reset h1 {
+  font-weight: 900;
+  font-size: 28px;
+  line-height: 32px;
+  color: var(--TextMedium);
+  text-align: justify;
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid var(--TextLight);
+}
+
+.vditor-reset h2 {
+  font-weight: 900;
+  font-size: 24px;
+  line-height: 28px;
+  color: var(--TextMedium);
+  text-align: justify;
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid var(--TextLight);
+}
+
+.vditor-reset h3 {
+  font-weight: 900;
+  font-size: 20px;
+  line-height: 24px;
+  color: var(--TextMedium);
+  text-align: justify;
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid var(--TextLight);
+}
+
+.vditor-reset h4 {
+  font-weight: 900;
+  font-size: 18px;
+  line-height: 22px;
+  color: var(--TextMedium);
+  text-align: justify;
+  display: flex;
+  align-items: center;
+}
+
+.vditor-reset h5 {
+  font-weight: 900;
+  font-size: 16px;
+  line-height: 20px;
+  color: var(--TextMedium);
+  text-align: justify;
+  display: flex;
+  align-items: center;
+}
+
+.vditor-reset h6 {
+  font-weight: 900;
+  font-size: 14px;
+  line-height: 18px;
+  color: var(--TextRegular);
+  text-align: justify;
+  display: flex;
+  align-items: center;
+}
+
+.vditor-reset h1,
+.vditor-reset h2,
+.vditor-reset h3,
+.vditor-reset h4,
+.vditor-reset h5,
+.vditor-reset h6 {
+  margin-bottom: 12px;
+}
+
+
+/* 分割线 */
+
+.vditor-reset hr {
+  border-bottom: 1px solid var(--TextLight);
+  transform-origin: 0 0;
+  transform: scale(1, 0.5);
+  height: 0;
+}
+
+/* 引用块 */
+
+.vditor-reset blockquote p{
+  font-weight: 200; /* ExtraLight */
+  font-size: 12px;
+  line-height: 18px;
+  color: var(--TextQuote);
+  text-align: justify;
+  display: flex;
+  align-items: center;
+}
+
+.vditor-reset blockquote p b,
+.vditor-reset blockquote p strong{
+  font-weight: 400; /* Regular */
+}
+
+/* 代码块 */
+
+.vditor-reset pre > code {
+  background-color: var(--SwissCoffee-500);
+}

--- a/public/css/content-theme/classic.css
+++ b/public/css/content-theme/classic.css
@@ -14,10 +14,21 @@
   --SwissCoffee-500: #F4F4F3;
 }
 
+.vditor {
+  border: none;
+}
+
 .vditor-reset {
   font-family: "Noto Serif SC";
   font-weight: 400px;
 }
+
+.vditor-wysiwyg pre.vditor-reset:focus,
+.vditor-ir pre.vditor-reset:focus,
+pre.vditor-sv:focus {
+  background: var(--White);
+}
+
 
 /* 段落 */
 

--- a/public/css/content-theme/modern.css
+++ b/public/css/content-theme/modern.css
@@ -1,144 +1,153 @@
 /*!
- * Classic content theme of ficus-editor
- *
- */
- @import url('https://fonts.googleapis.com/css2?family=Noto+Serif+SC:wght@100;300;400;500;700;900&display=swap');
- @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@100;300;400;500;700;900&display=swap');
- 
- :root {
-   --White: #FFFFFF;
-   --TextMedium: #3D3D3D;
-   --TextRegular: #5E5E5E;
-   --TextLight: #D8D8D8;
-   --TextQuote: #AAAAAA;
-   --SwissCoffee-500: #F4F4F3;
- }
- 
- .vditor-reset {
-   font-family: "Noto Sans SC";
-   font-weight: 400px;
- }
- 
- /* 段落 */
- 
- .vditor-reset p {
-   font-weight: 400; /* Regular */
-   font-size: 12px;
-   line-height: 18px;
-   color: var(--TextMedium);
-   text-align: justify;
-   vertical-align: center;
-   margin-bottom: 12px;
- }
- 
- .vditor-reset p b, 
- .vditor-reset p strong {
-   font-weight: 900;
- } 
- 
- /* 标题 */
- 
- .vditor-reset h1 {
-   font-weight: 900;
-   font-size: 28px;
-   line-height: 32px;
-   color: var(--TextMedium);
-   text-align: justify;
-   display: flex;
-   align-items: center;
-   border-bottom: 1px solid var(--TextLight);
- }
- 
- .vditor-reset h2 {
-   font-weight: 900;
-   font-size: 24px;
-   line-height: 28px;
-   color: var(--TextMedium);
-   text-align: justify;
-   display: flex;
-   align-items: center;
-   border-bottom: 1px solid var(--TextLight);
- }
- 
- .vditor-reset h3 {
-   font-weight: 900;
-   font-size: 20px;
-   line-height: 24px;
-   color: var(--TextMedium);
-   text-align: justify;
-   display: flex;
-   align-items: center;
-   border-bottom: 1px solid var(--TextLight);
- }
- 
- .vditor-reset h4 {
-   font-weight: 900;
-   font-size: 18px;
-   line-height: 22px;
-   color: var(--TextMedium);
-   text-align: justify;
-   display: flex;
-   align-items: center;
- }
- 
- .vditor-reset h5 {
-   font-weight: 900;
-   font-size: 16px;
-   line-height: 20px;
-   color: var(--TextMedium);
-   text-align: justify;
-   display: flex;
-   align-items: center;
- }
- 
- .vditor-reset h6 {
-   font-weight: 900;
-   font-size: 14px;
-   line-height: 18px;
-   color: var(--TextRegular);
-   text-align: justify;
-   display: flex;
-   align-items: center;
- }
- 
- .vditor-reset h1,
- .vditor-reset h2,
- .vditor-reset h3,
- .vditor-reset h4,
- .vditor-reset h5,
- .vditor-reset h6 {
-   margin-bottom: 12px;
- }
- 
- 
- /* 分割线 */
- 
- .vditor-reset hr {
-   border-bottom: 1px solid var(--TextLight);
-   transform-origin: 0 0;
-   transform: scale(1, 0.5);
-   height: 0;
- }
- 
- /* 引用块 */
- 
- .vditor-reset blockquote p{
-   font-weight: 200; /* ExtraLight */
-   font-size: 12px;
-   line-height: 18px;
-   color: var(--TextQuote);
-   text-align: justify;
-   display: flex;
-   align-items: center;
- }
- 
- .vditor-reset blockquote p b,
- .vditor-reset blockquote p strong{
-   font-weight: 400; /* Regular */
- }
- 
- /* 代码块 */
- 
- .vditor-reset pre > code {
-   background-color: var(--SwissCoffee-500);
- }
+* Modern content theme of ficus-editor
+*
+*/
+@import url('https://fonts.googleapis.com/css2?family=Noto+Serif+SC:wght@100;300;400;500;700;900&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@100;300;400;500;700;900&display=swap');
+
+:root {
+    --White: #FFFFFF;
+    --TextMedium: #3D3D3D;
+    --TextRegular: #5E5E5E;
+    --TextLight: #D8D8D8;
+    --TextQuote: #AAAAAA;
+    --SwissCoffee-500: #F4F4F3;
+}
+.vditor {
+    border: none;
+}
+
+.vditor-reset {
+    font-family: "Noto Sans SC";
+    font-weight: 400px;
+}
+
+.vditor-wysiwyg pre.vditor-reset:focus,
+.vditor-ir pre.vditor-reset:focus,
+pre.vditor-sv:focus {
+    background: var(--White);
+}
+
+/* 段落 */
+
+.vditor-reset p {
+    font-weight: 400; /* Regular */
+    font-size: 12px;
+    line-height: 18px;
+    color: var(--TextMedium);
+    text-align: justify;
+    vertical-align: center;
+    margin-bottom: 12px;
+}
+
+.vditor-reset p b,
+.vditor-reset p strong {
+    font-weight: 900;
+}
+
+/* 标题 */
+
+.vditor-reset h1 {
+    font-weight: 900;
+    font-size: 28px;
+    line-height: 32px;
+    color: var(--TextMedium);
+    text-align: justify;
+    display: flex;
+    align-items: center;
+    border-bottom: 1px solid var(--TextLight);
+}
+
+.vditor-reset h2 {
+    font-weight: 900;
+    font-size: 24px;
+    line-height: 28px;
+    color: var(--TextMedium);
+    text-align: justify;
+    display: flex;
+    align-items: center;
+    border-bottom: 1px solid var(--TextLight);
+}
+
+.vditor-reset h3 {
+    font-weight: 900;
+    font-size: 20px;
+    line-height: 24px;
+    color: var(--TextMedium);
+    text-align: justify;
+    display: flex;
+    align-items: center;
+    border-bottom: 1px solid var(--TextLight);
+}
+
+.vditor-reset h4 {
+    font-weight: 900;
+    font-size: 18px;
+    line-height: 22px;
+    color: var(--TextMedium);
+    text-align: justify;
+    display: flex;
+    align-items: center;
+}
+
+.vditor-reset h5 {
+    font-weight: 900;
+    font-size: 16px;
+    line-height: 20px;
+    color: var(--TextMedium);
+    text-align: justify;
+    display: flex;
+    align-items: center;
+}
+
+.vditor-reset h6 {
+    font-weight: 900;
+    font-size: 14px;
+    line-height: 18px;
+    color: var(--TextRegular);
+    text-align: justify;
+    display: flex;
+    align-items: center;
+}
+
+.vditor-reset h1,
+.vditor-reset h2,
+.vditor-reset h3,
+.vditor-reset h4,
+.vditor-reset h5,
+.vditor-reset h6 {
+    margin-bottom: 12px;
+}
+
+
+/* 分割线 */
+
+.vditor-reset hr {
+    border-bottom: 1px solid var(--TextLight);
+    transform-origin: 0 0;
+    transform: scale(1, 0.5);
+    height: 0;
+}
+
+/* 引用块 */
+
+.vditor-reset blockquote p{
+    font-weight: 200; /* ExtraLight */
+    font-size: 12px;
+    line-height: 18px;
+    color: var(--TextQuote);
+    text-align: justify;
+    display: flex;
+    align-items: center;
+}
+
+.vditor-reset blockquote p b,
+.vditor-reset blockquote p strong{
+    font-weight: 400; /* Regular */
+}
+
+/* 代码块 */
+
+.vditor-reset pre > code {
+    background-color: var(--SwissCoffee-500);
+}

--- a/public/css/content-theme/modern.css
+++ b/public/css/content-theme/modern.css
@@ -1,0 +1,144 @@
+/*!
+ * Classic content theme of ficus-editor
+ *
+ */
+ @import url('https://fonts.googleapis.com/css2?family=Noto+Serif+SC:wght@100;300;400;500;700;900&display=swap');
+ @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@100;300;400;500;700;900&display=swap');
+ 
+ :root {
+   --White: #FFFFFF;
+   --TextMedium: #3D3D3D;
+   --TextRegular: #5E5E5E;
+   --TextLight: #D8D8D8;
+   --TextQuote: #AAAAAA;
+   --SwissCoffee-500: #F4F4F3;
+ }
+ 
+ .vditor-reset {
+   font-family: "Noto Sans SC";
+   font-weight: 400px;
+ }
+ 
+ /* 段落 */
+ 
+ .vditor-reset p {
+   font-weight: 400; /* Regular */
+   font-size: 12px;
+   line-height: 18px;
+   color: var(--TextMedium);
+   text-align: justify;
+   vertical-align: center;
+   margin-bottom: 12px;
+ }
+ 
+ .vditor-reset p b, 
+ .vditor-reset p strong {
+   font-weight: 900;
+ } 
+ 
+ /* 标题 */
+ 
+ .vditor-reset h1 {
+   font-weight: 900;
+   font-size: 28px;
+   line-height: 32px;
+   color: var(--TextMedium);
+   text-align: justify;
+   display: flex;
+   align-items: center;
+   border-bottom: 1px solid var(--TextLight);
+ }
+ 
+ .vditor-reset h2 {
+   font-weight: 900;
+   font-size: 24px;
+   line-height: 28px;
+   color: var(--TextMedium);
+   text-align: justify;
+   display: flex;
+   align-items: center;
+   border-bottom: 1px solid var(--TextLight);
+ }
+ 
+ .vditor-reset h3 {
+   font-weight: 900;
+   font-size: 20px;
+   line-height: 24px;
+   color: var(--TextMedium);
+   text-align: justify;
+   display: flex;
+   align-items: center;
+   border-bottom: 1px solid var(--TextLight);
+ }
+ 
+ .vditor-reset h4 {
+   font-weight: 900;
+   font-size: 18px;
+   line-height: 22px;
+   color: var(--TextMedium);
+   text-align: justify;
+   display: flex;
+   align-items: center;
+ }
+ 
+ .vditor-reset h5 {
+   font-weight: 900;
+   font-size: 16px;
+   line-height: 20px;
+   color: var(--TextMedium);
+   text-align: justify;
+   display: flex;
+   align-items: center;
+ }
+ 
+ .vditor-reset h6 {
+   font-weight: 900;
+   font-size: 14px;
+   line-height: 18px;
+   color: var(--TextRegular);
+   text-align: justify;
+   display: flex;
+   align-items: center;
+ }
+ 
+ .vditor-reset h1,
+ .vditor-reset h2,
+ .vditor-reset h3,
+ .vditor-reset h4,
+ .vditor-reset h5,
+ .vditor-reset h6 {
+   margin-bottom: 12px;
+ }
+ 
+ 
+ /* 分割线 */
+ 
+ .vditor-reset hr {
+   border-bottom: 1px solid var(--TextLight);
+   transform-origin: 0 0;
+   transform: scale(1, 0.5);
+   height: 0;
+ }
+ 
+ /* 引用块 */
+ 
+ .vditor-reset blockquote p{
+   font-weight: 200; /* ExtraLight */
+   font-size: 12px;
+   line-height: 18px;
+   color: var(--TextQuote);
+   text-align: justify;
+   display: flex;
+   align-items: center;
+ }
+ 
+ .vditor-reset blockquote p b,
+ .vditor-reset blockquote p strong{
+   font-weight: 400; /* Regular */
+ }
+ 
+ /* 代码块 */
+ 
+ .vditor-reset pre > code {
+   background-color: var(--SwissCoffee-500);
+ }

--- a/src/renderer/components/richTextEditor/defineRAPI.js
+++ b/src/renderer/components/richTextEditor/defineRAPI.js
@@ -1,0 +1,48 @@
+import bus from 'vue3-eventbus'
+
+export default function defineRAPI (vditor) {
+  /** 设置编辑器内容 **/
+  bus.on('setEditorContent', ({ content }) => {
+    vditor.setValue(content)
+  })
+
+  /** 修改编辑模式 **/
+  bus.on('changeEditMode', ({ mode }) => {
+    if (mode === 0) {
+      vditor.changeEditMode('wysiwyg')
+    } else if (mode === 1) {
+      vditor.changeEditMode('sv')
+    } else {
+      vditor.changeEditMode('ir')
+    }
+  })
+
+  /** 修改内容主题 **/
+  bus.on('changeContentTheme', ({ theme }) => {
+    if (theme === 'classic') {
+      vditor.setTheme('classic', 'classic', 'github', '/css')
+    } else if (theme === 'modern') {
+      vditor.setTheme('classic', 'modern', 'github', '/css')
+    } else {
+      console.log('no match theme!')
+    }
+  })
+
+  /** 将用户选中的文本复制进剪切板 **/
+  bus.on('copySelectedText', () => {
+    const content = vditor.getSelection()
+
+    const textarea = document.createElement('textarea')
+    textarea.value = content
+    textarea.style.display = 'none'
+    document.body.appendChild(textarea)
+    textarea.select()
+    document.execCommand('copy')
+    document.body.removeChild(textarea)
+  })
+
+  /** 在光标处插入文本 **/
+  bus.on('insertText', ({ content }) => {
+    vditor.insertValue(content)
+  })
+}

--- a/src/renderer/components/richTextEditor/defineRAPI.js
+++ b/src/renderer/components/richTextEditor/defineRAPI.js
@@ -20,9 +20,9 @@ export default function defineRAPI (vditor) {
   /** 修改内容主题 **/
   bus.on('changeContentTheme', ({ theme }) => {
     if (theme === 'classic') {
-      vditor.setTheme('classic', 'classic', 'github', '/css')
+      vditor.setTheme('classic', 'classic', 'github', '/css/content-theme')
     } else if (theme === 'modern') {
-      vditor.setTheme('classic', 'modern', 'github', '/css')
+      vditor.setTheme('classic', 'modern', 'github', '/css/content-theme')
     } else {
       console.log('no match theme!')
     }

--- a/src/renderer/components/richTextEditor/index.vue
+++ b/src/renderer/components/richTextEditor/index.vue
@@ -8,6 +8,7 @@
 import { onMounted, onBeforeUnmount, watch, nextTick } from 'vue'
 import Vditor from 'ficus-editor'
 import 'ficus-editor/dist/index.css'
+import defineRAPI from './defineRAPI.js'
 
 export default {
   name: 'TextUI',
@@ -21,7 +22,7 @@ export default {
     let vditor
 
     // 初始化
-    function init () {
+    function initVditor () {
       // options
       const options =
       {
@@ -78,7 +79,10 @@ export default {
     // 初始化编辑器
     onMounted(() => {
       nextTick(() => {
-        init()
+        // 初始化vditor
+        initVditor()
+        // 定义和vditor相关的API, 使用全局事件总线实现
+        defineRAPI(vditor)
       })
     })
     // 销毁

--- a/src/renderer/components/richTextEditor/index.vue
+++ b/src/renderer/components/richTextEditor/index.vue
@@ -9,6 +9,7 @@ import { onMounted, onBeforeUnmount, watch, nextTick } from 'vue'
 import Vditor from 'ficus-editor'
 import 'ficus-editor/dist/index.css'
 import defineRAPI from './defineRAPI.js'
+import bus from 'vue3-eventbus'
 
 export default {
   name: 'TextUI',
@@ -49,17 +50,19 @@ export default {
             engine: 'KaTeX'
           }
         },
-        // 字数统计
-        counter: {
-          enable: false,
-          after (count) { /* todo */ } // 字数统计回调
-        },
         // 设置tab键渲染
         tab: '\t',
         // 打字机模式（类似与typora）
         typewriterMode: false,
         // 内容为空时的提示
-        placeholder: '请输入...'
+        placeholder: '请输入...',
+        // 用户输入回调函数，将最新的md字符串返回
+        input: (content) => {
+          bus.emit('saveChange', {
+            content: content,
+            wordCnt: content.length
+          })
+        }
       }
       // 根据options和默认设置创建vditor实例
       vditor = new Vditor('vditor', options)

--- a/src/renderer/components/richTextEditor/index.vue
+++ b/src/renderer/components/richTextEditor/index.vue
@@ -35,9 +35,10 @@ export default {
         cache: {
           enable: false
         },
-        // 创建实例后，将props中传入的内容展示出来
+        // 创建实例后，将props中传入的内容展示出来, 并隐藏工具栏
         after: () => {
           vditor.setValue(props.content)
+          vditor.hideToorBar()
         },
         // 预览模式选项
         preview: {

--- a/src/renderer/components/richTextEditor/index.vue
+++ b/src/renderer/components/richTextEditor/index.vue
@@ -49,6 +49,11 @@ export default {
           // 数学公式渲染选项
           math: {
             engine: 'KaTeX'
+          },
+          // 设置默认主题
+          theme: {
+            current: 'classic',
+            path: 'css/content-theme'
           }
         },
         // 设置tab键渲染


### PR DESCRIPTION
完成以下工作：
- 定义了四个和Vue Controller交互的接口，实现切换内容主题、切换编辑模式，复制，粘贴
- 隐藏原有的工具栏
- 完成内容主题对应的css文件，放入public/css/content-theme文件夹下
- 增加用户输入回调函数，实时返回最新的md字符串和字数