### PR TITLE
用户修改文件时，同时返回光标位置（range）

### DIFF
--- a/src/renderer/components/richTextEditor/index.vue
+++ b/src/renderer/components/richTextEditor/index.vue
@@ -88,7 +88,8 @@ export default {
           bus.emit('saveChange', {
             content: content,
             wordCnt: content.length,
-            lineCnt: content.split('\n').length - 1
+            lineCnt: content.split('\n').length - 1,
+            range: vditor.getEditorRange()
           })
         },
         // 针对文件链接的回调函数


### PR DESCRIPTION
saveChange接口的参数修改为
```
{
	content: '',
	wordCnt: 0,
	lineCnt: 0,
	range: ''
}
```
其中range存储焦点位置